### PR TITLE
Add package-lint as a dependency of the test-suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export PACKAGE_FILE=$(word 1,$(SRCS))
 export PACKAGE_LISP=$(SRCS) $(TESTS)
 export PACKAGE_ARCHIVES=melpa
 
-export PACKAGE_TEST_DEPS=libmpdel
+export PACKAGE_TEST_DEPS=libmpdel package-lint
 export PACKAGE_TEST_ARCHIVES=melpa
 
 EMAKE_PATH = ../emake

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ export PACKAGE_ARCHIVES=melpa
 export PACKAGE_TEST_DEPS=libmpdel package-lint
 export PACKAGE_TEST_ARCHIVES=melpa
 
+export PACKAGE_IGNORE_DEPS=libmpdel
+
 EMAKE_PATH = ../emake
 
 LOAD_PATH = -L . -L $(EMAKE_PATH)  -L ../package-lint -L ../libmpdel


### PR DESCRIPTION
This should be squashed into the previous commit.  Together with the `PACKAGE_IGNORE_DEPS` changes from emake (vermiculus/emake.el#14), this should now work as intended.

After emake changes, the environment variable should be set thus:

    export PACKAGE_IGNORE_DEPS=libmpdel

Normally I wouldn't export the variable but that's what you're doing everywhere else.

Before testing, make sure to update the copy of emake.el in your directory to that of the upstream PR.