### PR TITLE
display file name if missing song name metadata

### DIFF
--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -108,7 +108,8 @@
 
 (navigel-method mpdel navigel-entity-to-columns ((song libmpdel-song))
   (vector
-   (propertize (or (libmpdel-entity-name song) "") 'face 'mpdel-tablist-song-name-face)
+   (propertize (or (libmpdel-entity-name song)
+                   (libmpdel-song-file song) "") 'face 'mpdel-tablist-song-name-face)
    (propertize (or (libmpdel-song-track song) "") 'face 'mpdel-tablist-track-face)
    (propertize (or (libmpdel-album-name song) "") 'face 'mpdel-tablist-album-face)
    (propertize (or (libmpdel-song-disc song) "") 'face 'mpdel-tablist-disk-face)


### PR DESCRIPTION
HTTP streams defined in playlist files do not contain metadata until
_after_ the stream begins playing.  Therefore, it can be difficult to
distinguish between the streams when nothing is displayed for each entry
in the playlist.  I cannot foresee an instance where the file name is
missing, but this may be failure of my imagination.

Therefore, if the song title is missing, display the file name instead.

This behaviour is consistent with `ncmpcpp` sans special formatting
which `ncmpcpp` does to tracks starting with "http...".