### PR TITLE
Display more metadata

### DIFF
--- a/mpdel-browser.el
+++ b/mpdel-browser.el
@@ -48,9 +48,9 @@
 
 (defcustom mpdel-browser-top-level-entries
   '(directories empty-line
-    albums artists empty-line
+    albums artists genres empty-line
     stored-playlists current-playlist empty-line
-    search-album search-title search-artist search-filter)
+    search-album search-title search-artist search-genre search-filter)
   "A list of the entries to show in the browser's top level buffer.
 
 Each entry is shown as a selectable line with the entry's
@@ -59,12 +59,14 @@ its contents in a new buffer."
   :type '(repeat (choice (const :tag "Directories" directories)
                          (string :tag "Directory")
                          (const :tag "All albums" albums)
+                         (const :tag "All genres" genres)
                          (const :tag "All artists" artists)
                          (const :tag "Stored playlists" stored-playlists)
                          (const :tag "Current playlist" current-playlist)
                          (const :tag "Search by artist" search-artist)
                          (const :tag "Search by album" search-album)
                          (const :tag "Search by title" search-title)
+                         (const :tag "Search by genre" search-genre)
                          (const :tag "Search using filter" search-filter)
                          (const :tag "Separator" empty-line))))
 
@@ -184,6 +186,7 @@ orderings."
 (mpdel-browser--defsearch album)
 (mpdel-browser--defsearch artist)
 (mpdel-browser--defsearch title)
+(mpdel-browser--defsearch genre)
 (mpdel-browser--defsearch filter)
 
 (cl-defmethod libmpdel-entity-name ((path string))

--- a/mpdel-browser.el
+++ b/mpdel-browser.el
@@ -4,8 +4,8 @@
 
 ;; Author: Jose A Ortega Ruiz <jao@gnu.org>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/mpdel-core.el
+++ b/mpdel-core.el
@@ -4,8 +4,8 @@
 
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/mpdel-playlist.el
+++ b/mpdel-playlist.el
@@ -4,8 +4,8 @@
 
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/mpdel-song.el
+++ b/mpdel-song.el
@@ -4,8 +4,8 @@
 
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/mpdel-song.el
+++ b/mpdel-song.el
@@ -126,16 +126,32 @@ when the song changes.")
            (libmpdel-time-to-string (cdr (assq 'elapsed data)))
            (libmpdel-time-to-string (cdr (assq 'duration data))))))
 
+(defun mpdel-song--join-indented (entities)
+  "Produce an indented list of the names of libmpdel-entities ENTITIES."
+  (string-join
+   (mapcar (lambda (entity)
+             (concat "\t- " (libmpdel-entity-name entity)))
+           entities)
+   "\n"))
+
 (defun mpdel-song--display-metadata ()
   "Give information about current song metadata."
   (let* ((song mpdel-song-song)
          (title (or (libmpdel-entity-name song) ""))
          (album (or (libmpdel-album-name song) ""))
-         (artist (or (libmpdel-artist-name song) "")))
-    (insert (format "Title: %s\nArtist: %s\nAlbum: %s\n"
+         (date (or (libmpdel--song-date song) ""))
+         (track (or (libmpdel--song-track song) ""))
+         (artists (mpdel-song--join-indented (libmpdel-artists song)))
+         (genres (mpdel-song--join-indented (libmpdel-genres song)))
+         (performers (mpdel-song--join-indented (libmpdel-performers song))))
+    (insert (format "Title: %s\nArtist:\n%s\nAlbum: %s\nTrack: %s\nDate: %s\nGenre:\n%s\nPerformers:\n%s\n"
                     title
-                    artist
-                    album))))
+                    artists
+                    album
+                    track
+                    date
+                    genres
+                    performers))))
 
 (defun mpdel-song--refresh-current-song (data buffer)
   "Write information about currently-played song in DATA to BUFFER.

--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -144,6 +144,9 @@
 (navigel-method mpdel navigel-tablist-format ((_entity (eql current-playlist)))
   (mpdel-tablist--song-format))
 
+(navigel-method mpdel navigel-tablist-format ((_entity (eql albums)))
+  (mpdel-tablist--album-format))
+
 (navigel-method mpdel navigel-tablist-format ((_entity (eql genres)))
   (mpdel-tablist--genre-format))
 

--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -113,9 +113,9 @@
   (vector (list "Name" 0 t)))
 
 (navigel-method mpdel navigel-entity-to-columns ((entity libmpdel-album))
-  (vector (libmpdel-entity-name entity)
-          (libmpdel-entity-date entity)
-          (libmpdel-artists-name entity)))
+  (vector (or (libmpdel-entity-name entity) "")
+          (or (libmpdel-entity-date entity) "")
+          (or (libmpdel-artists-name entity) "")))
 
 (navigel-method mpdel navigel-entity-to-columns ((song libmpdel-song))
   (vector

--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -104,7 +104,7 @@
           (list "#" 6 nil)
           (list "Album" 30 t)
           (list "Disk" 4 t)
-          (list "Date" 5 t)
+          (list "Date" 12 t)
           (list "Artist" 0 t)))
 
 (defun mpdel-tablist--genre-format ()

--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -4,8 +4,8 @@
 
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -113,9 +113,9 @@
   (vector (list "Name" 0 t)))
 
 (navigel-method mpdel navigel-entity-to-columns ((entity libmpdel-album))
-  (vector (or (libmpdel-entity-name entity) "")
-          (or (libmpdel-entity-date entity) "")
-          (or (libmpdel-artists-name entity) "")))
+  (vector (propertize (or (libmpdel-entity-name entity) "") 'face 'mpdel-tablist-album-face)
+          (propertize (or (libmpdel-entity-date entity) "") 'face 'mpdel-tablist-date-face)
+          (propertize (or (libmpdel-artists-name entity) "") 'face 'mpdel-tablist-artist-face)))
 
 (navigel-method mpdel navigel-entity-to-columns ((song libmpdel-song))
   (vector

--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -115,7 +115,7 @@
 (navigel-method mpdel navigel-entity-to-columns ((entity libmpdel-album))
   (vector (libmpdel-entity-name entity)
           (libmpdel-entity-date entity)
-          (libmpdel-artist-name entity)))
+          (libmpdel-artists-name entity)))
 
 (navigel-method mpdel navigel-entity-to-columns ((song libmpdel-song))
   (vector

--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -124,7 +124,7 @@
    (propertize (or (libmpdel-album-name song) "") 'face 'mpdel-tablist-album-face)
    (propertize (or (libmpdel-song-disc song) "") 'face 'mpdel-tablist-disk-face)
    (propertize (or (libmpdel-entity-date song) "") 'face 'mpdel-tablist-date-face)
-   (propertize (or (libmpdel-artist-name song) "") 'face 'mpdel-tablist-artist-face)))
+   (propertize (or (libmpdel-artists-name song) "") 'face 'mpdel-tablist-artist-face)))
 
 (navigel-method mpdel navigel-tablist-format ((_entity libmpdel-artist))
   (mpdel-tablist--album-format))

--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -72,6 +72,9 @@
 (navigel-method mpdel navigel-entity-tablist-mode ((_entity (eql albums)))
   (mpdel-tablist-mode))
 
+(navigel-method mpdel navigel-entity-tablist-mode ((_entity (eql genres)))
+  (mpdel-tablist-mode))
+
 (navigel-method mpdel navigel-entity-tablist-mode ((_entity libmpdel-search-criteria))
   (mpdel-tablist-mode))
 
@@ -84,6 +87,8 @@
 (navigel-method mpdel navigel-entity-tablist-mode ((_entity libmpdel-album))
   (mpdel-tablist-mode))
 
+(navigel-method mpdel navigel-entity-tablist-mode ((_entity libmpdel-genre))
+  (mpdel-tablist-mode))
 
 
 ;;; `navigel' tabulated list configuration
@@ -101,6 +106,10 @@
           (list "Disk" 4 t)
           (list "Date" 5 t)
           (list "Artist" 0 t)))
+
+(defun mpdel-tablist--genre-format ()
+  "Return `tabulated-list-format' value for genres."
+  (vector (list "Name" 0 t)))
 
 (navigel-method mpdel navigel-entity-to-columns ((entity libmpdel-album))
   (vector (libmpdel-entity-name entity)
@@ -121,6 +130,9 @@
 (navigel-method mpdel navigel-tablist-format ((_entity libmpdel-album))
   (mpdel-tablist--song-format))
 
+(navigel-method mpdel navigel-tablist-format ((_entity libmpdel-genre))
+  (mpdel-tablist--song-format))
+
 (navigel-method mpdel navigel-tablist-format ((_entity libmpdel-search-criteria))
   (mpdel-tablist--song-format))
 
@@ -129,6 +141,9 @@
 
 (navigel-method mpdel navigel-tablist-format ((_entity (eql current-playlist)))
   (mpdel-tablist--song-format))
+
+(navigel-method mpdel navigel-tablist-format ((_entity (eql genres)))
+  (mpdel-tablist--genre-format))
 
 (navigel-method mpdel navigel-tablist-format ((_entity libmpdel-stored-playlist))
   (mpdel-tablist--song-format))

--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -96,6 +96,7 @@
 (defun mpdel-tablist--album-format ()
   "Return `tabulated-list-format' value for albums."
   (vector (list "Name" 40 t)
+          (list "Date" 12 t)
           (list "Artist" 0 t)))
 
 (defun mpdel-tablist--song-format ()
@@ -113,6 +114,7 @@
 
 (navigel-method mpdel navigel-entity-to-columns ((entity libmpdel-album))
   (vector (libmpdel-entity-name entity)
+          (libmpdel-entity-date entity)
           (libmpdel-artist-name entity)))
 
 (navigel-method mpdel navigel-entity-to-columns ((song libmpdel-song))

--- a/mpdel.el
+++ b/mpdel.el
@@ -4,8 +4,8 @@
 
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1") (libmpdel "1.2.0") (navigel "0.7.0"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1") (libmpdel "1.2.0") (navigel "0.7.0"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Various changes to display more metadata, such as multiple artists, album years, etc, reflecting recent changes in libmpdel.

Also allows listing available genres and searching/filtering by genre.

If you want me to split this up into several PRs, just let me know, I figured this could probably all be tested in one go.