### PR TITLE
Make the linter happy

### DIFF
--- a/mpdel-browser.el
+++ b/mpdel-browser.el
@@ -4,8 +4,8 @@
 
 ;; Author: Jose A Ortega Ruiz <jao@gnu.org>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/mpdel-core.el
+++ b/mpdel-core.el
@@ -4,8 +4,8 @@
 
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/mpdel-playlist.el
+++ b/mpdel-playlist.el
@@ -4,8 +4,8 @@
 
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/mpdel-song.el
+++ b/mpdel-song.el
@@ -4,8 +4,8 @@
 
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/mpdel-tablist.el
+++ b/mpdel-tablist.el
@@ -4,8 +4,8 @@
 
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/mpdel.el
+++ b/mpdel.el
@@ -4,8 +4,8 @@
 
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; Keywords: multimedia
-;; Url: https://github.com/mpdel/mpdel
-;; Package-requires: ((emacs "25.1") (libmpdel "1.2.0") (navigel "0.7.0"))
+;; URL: https://github.com/mpdel/mpdel
+;; Package-Requires: ((emacs "25.1") (libmpdel "1.2.0") (navigel "0.7.0"))
 ;; Version: 2.1.0
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
It seems there are new linting requirements related to the header -
they go away when `Url:` is substituted by `URL:` and
`Package-requires:` by `Package-Requires:`.  This PR makes that change
in all mpdel elisp files