### PR TITLE
Explicitly list all .el files in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ ELPA_DEPENDENCIES=package-lint let-alist libmpdel navigel tablist
 
 ELPA_ARCHIVES=melpa gnu
 
-LINT_CHECKDOC_FILES=$(wildcard *.el)
-LINT_PACKAGE_LINT_FILES=$(wildcard *.el)
-LINT_COMPILE_FILES=$(wildcard *.el)
+LINT_CHECKDOC_FILES = mpdel-browser.el mpdel-core.el mpdel.el mpdel-playlist.el mpdel-song.el mpdel-tablist.el
+LINT_PACKAGE_LINT_FILES = ${LINT_CHECKDOC_FILES}
+LINT_COMPILE_FILES = ${LINT_CHECKDOC_FILES}
 
 makel.mk:
 	# Download makel


### PR DESCRIPTION
When (lib)mpdel is built for guix, a (lib)mpdel-pkg.el file is
auto-generated - this trips up the linter, since it doesn't have the
conventional header comments.  By explicitly listing which .el files
to include, this can be prevented.  I suspect that this also happens
on some other platforms, but don't know for sure

There is a corresponding PR on libmpdel, see https://github.com/mpdel/libmpdel/pull/20