### PR TITLE
mpdel-song: add random/repeat status to *MPDEL Current Song*

### DIFF
--- a/mpdel-song.el
+++ b/mpdel-song.el
@@ -119,6 +119,14 @@ when the song changes.")
     ('stop (insert "Currently stopped\n")
            (mpdel-song--stop-timer))))
 
+(defun mpdel-song--display-random-state ()
+  "Give information about random playback."
+  (insert (format "Random: %s\n" (if libmpdel--random "Yes" "No"))))
+
+(defun mpdel-song--display-repeat-state ()
+  "Give information about repeated playback."
+  (insert (format "Repeat: %s\n" (if libmpdel--repeat "Yes" "No"))))
+
 (defun mpdel-song--display-play-time (data)
   "Give information about current play time in DATA."
   (insert
@@ -164,6 +172,8 @@ In particular, it must contain key symbol `elapsed' and symbol
       (erase-buffer)
       (setq mpdel-song-song (libmpdel-current-song))
       (mpdel-song--display-play-state)
+      (mpdel-song--display-random-state)
+      (mpdel-song--display-repeat-state)
       (mpdel-song--display-metadata)
       (mpdel-song--display-play-time data))))
 


### PR DESCRIPTION
We add two new private functions for adding the random and repeat statuses to the *MPDEL Current Song* buffer.

Certainly, this change could be extended with some custom faces/variables or some way to allow users to use emoticons or similar for displaying these flags.  However, using simple text messages feels sufficient for the desired purpose.

Alternatively, if either of these flags are not set (or #f), we could simply not display the respective line.  For example, when `libmpdel--random` is true, the current song buffer displays, "Random: Yes"; otherwise, it displays nothing.  Dually for `limpdel--repeat`.

This closes mpdel/mpdel#30.